### PR TITLE
feat: configure live2d positioning type

### DIFF
--- a/packages/webgal/public/game/config.txt
+++ b/packages/webgal/public/game/config.txt
@@ -7,3 +7,4 @@ Default_Language:zh_CN;
 Show_panic:true;
 Enable_Appreciation:true;
 Legacy_Expression_Blend_Mode:true;
+Positioning_Type:M_3_1_0;

--- a/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
@@ -2,7 +2,7 @@ import { webgalStore } from '@/store/store';
 import { IEffect, IFigureAssociatedAnimation, IFigureMetadata, ITransform } from '@/store/stageInterface';
 import { setStage, stageActions } from '@/store/stageReducer';
 import { Live2D, WebGAL } from '@/Core/WebGAL';
-import { baseBlinkParam, baseFocusParam, BlinkParam, FocusParam } from '@/Core/live2DCore';
+import { baseBlinkParam, baseFocusParam, BlinkParam, FocusParam, PositioningType } from '@/Core/live2DCore';
 import { isIOS } from '@/Core/initializeScript';
 import { WebGALPixiContainer } from '@/Core/controller/stage/pixi/WebGALPixiContainer';
 import { addSpineBgImpl, addSpineFigureImpl } from '@/Core/controller/stage/pixi/spine';
@@ -419,22 +419,8 @@ export default class PixiStage {
           /**
            * 重设大小
            */
-          const originalWidth = texture.width;
-          const originalHeight = texture.height;
-          const scaleX = this.stageWidth / originalWidth;
-          const scaleY = this.stageHeight / originalHeight;
-          const targetScale = Math.max(scaleX, scaleY);
           const bgSprite = new PIXI.Sprite(texture);
-          bgSprite.scale.x = targetScale;
-          bgSprite.scale.y = targetScale;
-          bgSprite.anchor.set(0.5);
-          bgSprite.position.y = this.stageHeight / 2;
-          thisBgContainer.setBaseX(this.stageWidth / 2);
-          thisBgContainer.setBaseY(this.stageHeight / 2);
-          thisBgContainer.pivot.set(0, this.stageHeight / 2);
-
-          // 挂载
-          thisBgContainer.addChild(bgSprite);
+          this.setContainerInitialPosition(thisBgContainer, bgSprite, texture.width, texture.height, 'bg', false);
         }
       }, 0);
     };
@@ -504,20 +490,15 @@ export default class PixiStage {
            * 重设大小
            */
           texture.baseTexture.resource.load().then(() => {
-            const originalWidth = videoResource.source.videoWidth;
-            const originalHeight = videoResource.source.videoHeight;
-            const scaleX = this.stageWidth / originalWidth;
-            const scaleY = this.stageHeight / originalHeight;
-            const targetScale = Math.max(scaleX, scaleY);
             const bgSprite = new PIXI.Sprite(texture);
-            bgSprite.scale.x = targetScale;
-            bgSprite.scale.y = targetScale;
-            bgSprite.anchor.set(0.5);
-            bgSprite.position.y = this.stageHeight / 2;
-            thisBgContainer.setBaseX(this.stageWidth / 2);
-            thisBgContainer.setBaseY(this.stageHeight / 2);
-            thisBgContainer.pivot.set(0, this.stageHeight / 2);
-            thisBgContainer.addChild(bgSprite);
+            this.setContainerInitialPosition(
+              thisBgContainer,
+              bgSprite,
+              videoResource.source.videoWidth,
+              videoResource.source.videoHeight,
+              'bg',
+              false,
+            );
           });
         }
       }, 0);
@@ -582,33 +563,15 @@ export default class PixiStage {
           /**
            * 重设大小
            */
-          const originalWidth = texture.width;
-          const originalHeight = texture.height;
-          const scaleX = this.stageWidth / originalWidth;
-          const scaleY = this.stageHeight / originalHeight;
-          const targetScale = Math.min(scaleX, scaleY);
           const figureSprite = new PIXI.Sprite(texture);
-          figureSprite.scale.x = targetScale;
-          figureSprite.scale.y = targetScale;
-          figureSprite.anchor.set(0.5);
-          figureSprite.position.y = this.stageHeight / 2;
-          const targetWidth = originalWidth * targetScale;
-          const targetHeight = originalHeight * targetScale;
-          thisFigureContainer.setBaseY(this.stageHeight / 2);
-          if (targetHeight < this.stageHeight) {
-            thisFigureContainer.setBaseY(this.stageHeight / 2 + (this.stageHeight - targetHeight) / 2);
-          }
-          if (presetPosition === 'center') {
-            thisFigureContainer.setBaseX(this.stageWidth / 2);
-          }
-          if (presetPosition === 'left') {
-            thisFigureContainer.setBaseX(targetWidth / 2);
-          }
-          if (presetPosition === 'right') {
-            thisFigureContainer.setBaseX(this.stageWidth - targetWidth / 2);
-          }
-          thisFigureContainer.pivot.set(0, this.stageHeight / 2);
-          thisFigureContainer.addChild(figureSprite);
+          this.setContainerInitialPosition(
+            thisFigureContainer,
+            figureSprite,
+            texture.width,
+            texture.height,
+            presetPosition,
+            false,
+          );
         }
       }, 0);
     };
@@ -662,40 +625,10 @@ export default class PixiStage {
       // ✅ 使用 AnimatedGIF.fromBuffer 异步解码
       const gif = await AnimatedGIF.fromBuffer(buffer);
 
-      const originalWidth = gif.width;
-      const originalHeight = gif.height;
-      const scaleX = this.stageWidth / originalWidth;
-      const scaleY = this.stageHeight / originalHeight;
-      const targetScale = Math.min(scaleX, scaleY);
-
-      // 设置缩放、锚点、初始位置
-      gif.scale.set(targetScale);
-      gif.anchor.set(0.5);
-      gif.position.y = this.stageHeight / 2;
-
-      const targetWidth = originalWidth * targetScale;
-      const targetHeight = originalHeight * targetScale;
-
-      // Y 位置微调（让立绘整体居中）
-      thisFigureContainer.setBaseY(this.stageHeight / 2);
-      if (targetHeight < this.stageHeight) {
-        thisFigureContainer.setBaseY(this.stageHeight / 2 + (this.stageHeight - targetHeight) / 2);
-      }
-
-      // 设置 X 方向位置
-      if (presetPosition === 'center') {
-        thisFigureContainer.setBaseX(this.stageWidth / 2);
-      } else if (presetPosition === 'left') {
-        thisFigureContainer.setBaseX(targetWidth / 2);
-      } else if (presetPosition === 'right') {
-        thisFigureContainer.setBaseX(this.stageWidth - targetWidth / 2);
-      }
-
-      thisFigureContainer.pivot.set(0, this.stageHeight / 2);
+      this.setContainerInitialPosition(thisFigureContainer, gif, gif.width, gif.height, presetPosition, false);
 
       // ✅ 播放动画 + 添加到容器
       gif.play();
-      thisFigureContainer.addChild(gif);
     } catch (e) {
       console.error('GIF 加载失败', e);
     }
@@ -795,52 +728,21 @@ export default class PixiStage {
           if (!model) continue;
           // 暂时隐藏模型，等全部模型加载后再统一显示
           model.visible = false;
-
-          const stageWidth = this.stageWidth;
-          const stageHeight = this.stageHeight;
-
-          const scaleX = stageWidth / model.width;
-          const scaleY = stageHeight / model.height;
-          const targetScale = Math.min(scaleX, scaleY);
-
-          const targetWidth = model.width * targetScale;
-          const targetHeight = model.height * targetScale;
-
-          const finalScaleX = targetScale * (xscale ?? 1);
-          const finalScaleY = targetScale * (yscale ?? 1);
-          model.scale.set(finalScaleX, finalScaleY);
-
-          model.anchor.set(0.5);
-          model.position.set(x ?? 0, stageHeight / 2 + (y ?? 0));
-
-          container.setBaseY(stageHeight / 2);
-          if (targetHeight < stageHeight) {
-            container.setBaseY(stageHeight / 2 + (stageHeight - targetHeight) / 2);
-          }
-
-          if (presetPosition === 'center') {
-            container.setBaseX(stageWidth / 2);
-          } else if (presetPosition === 'left') {
-            container.setBaseX(targetWidth / 2);
-          } else if (presetPosition === 'right') {
-            container.setBaseX(stageWidth - targetWidth / 2);
-          }
-
-          container.pivot.set(0, stageHeight / 2);
-          container.addChild(model);
+          this.setContainerInitialPosition(
+            container,
+            model,
+            model.width,
+            model.height,
+            presetPosition,
+            true,
+            undefined, // 聚合模型暂时想不到怎么使用 overrideBounds
+            x,
+            y,
+            xscale,
+            yscale,
+            true,
+          );
           models.push(model);
-
-          // ✅ 禁用自动旋转（防止抖动或头部异常移动）
-          // 感谢Hardy-Lee桑
-          if (model.internalModel.angleXParamIndex !== undefined) model.internalModel.angleXParamIndex = 999;
-          if (model.internalModel.angleYParamIndex !== undefined) model.internalModel.angleYParamIndex = 999;
-          if (model.internalModel.angleZParamIndex !== undefined) model.internalModel.angleZParamIndex = 999;
-
-          // @ts-ignore 禁用自动眨眼
-          if (model.internalModel?.eyeBlink) {
-            model.internalModel.eyeBlink.blinkInterval = 1000 * 60 * 60 * 24;
-            model.internalModel.eyeBlink.nextBlinkTimeLeft = 1000 * 60 * 60 * 24;
-          }
 
           // 每个模型加载完立刻设置 PARAM_IMPORT
           if (paramImport !== null) {
@@ -924,34 +826,14 @@ export default class PixiStage {
 
       // 加载后获取原始宽高
       video.onloadedmetadata = () => {
-        const originalWidth = video.videoWidth;
-        const originalHeight = video.videoHeight;
-        const scaleX = this.stageWidth / originalWidth;
-        const scaleY = this.stageHeight / originalHeight;
-        const targetScale = Math.min(scaleX, scaleY);
-
-        sprite.scale.set(targetScale);
-        sprite.anchor.set(0.5);
-        sprite.position.y = this.stageHeight / 2;
-
-        const targetWidth = originalWidth * targetScale;
-        const targetHeight = originalHeight * targetScale;
-
-        thisFigureContainer.setBaseY(this.stageHeight / 2);
-        if (targetHeight < this.stageHeight) {
-          thisFigureContainer.setBaseY(this.stageHeight / 2 + (this.stageHeight - targetHeight) / 2);
-        }
-
-        if (presetPosition === 'center') {
-          thisFigureContainer.setBaseX(this.stageWidth / 2);
-        } else if (presetPosition === 'left') {
-          thisFigureContainer.setBaseX(targetWidth / 2);
-        } else if (presetPosition === 'right') {
-          thisFigureContainer.setBaseX(this.stageWidth - targetWidth / 2);
-        }
-
-        thisFigureContainer.pivot.set(0, this.stageHeight / 2);
-        thisFigureContainer.addChild(sprite);
+        this.setContainerInitialPosition(
+          thisFigureContainer,
+          sprite,
+          video.videoWidth,
+          video.videoHeight,
+          presetPosition,
+          false,
+        );
       };
 
       // 错误处理
@@ -966,7 +848,7 @@ export default class PixiStage {
    * @param jsonPath
    */
   // eslint-disable-next-line max-params
-  public addLive2dFigure(key: string, jsonPath: string, pos: string) {
+  public addLive2dFigure(key: string, jsonPath: string, pos: 'left' | 'center' | 'right') {
     if (Live2D.isAvailable !== true) return;
     try {
       let stageWidth = this.stageWidth;
@@ -1007,7 +889,7 @@ export default class PixiStage {
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const instance = this;
 
-      const setup = () => {
+      const setup = (stage: PixiStage) => {
         if (thisFigureContainer && this.getStageObjByUuid(figureUuid)) {
           (async function () {
             let overrideBounds: [number, number, number, number] = [0, 0, 0, 0];
@@ -1029,33 +911,15 @@ export default class PixiStage {
             ]);
 
             models.forEach((model) => {
-              const scaleX = stageWidth / model.width;
-              const scaleY = stageHeight / model.height;
-              const targetScale = Math.min(scaleX, scaleY) * 1.25;
-              // const targetWidth = model.width * targetScale;
-              const targetHeight = model.height * targetScale;
-              model.scale.x = targetScale;
-              model.scale.y = targetScale;
-              model.anchor.set(0.5);
-              model.pivot.x += (overrideBounds[0] + overrideBounds[2]) * 0.5;
-              model.pivot.y += (overrideBounds[1] + overrideBounds[3]) * 0.5;
-              // model.position.x = 0;
-              model.position.y = stageHeight / 1.8;
-
-              let baseY = stageHeight / 2;
-              if (targetHeight < stageHeight) {
-                baseY = stageHeight / 2 + (stageHeight - targetHeight) / 2;
-              }
-              thisFigureContainer.setBaseY(baseY);
-              if (pos === 'center') {
-                thisFigureContainer.setBaseX(stageWidth / 2);
-              } else if (pos === 'left') {
-                thisFigureContainer.setBaseX(850);
-              } else if (pos === 'right') {
-                thisFigureContainer.setBaseX(1710);
-              }
-
-              thisFigureContainer.pivot.set(0, stageHeight / 2);
+              stage.setContainerInitialPosition(
+                thisFigureContainer,
+                model,
+                model.width,
+                model.height,
+                pos,
+                true,
+                overrideBounds,
+              );
 
               let animation_index = 0;
               let priority_number = 3;
@@ -1108,8 +972,6 @@ export default class PixiStage {
                   instance.setModelMouthY(key, currentMouthValue);
                 }
               });
-
-              thisFigureContainer.addChild(model);
             });
           })();
         }
@@ -1121,10 +983,10 @@ export default class PixiStage {
       const resourses = Object.keys(loader.resources);
       this.cacheGC();
       if (!resourses.includes(jsonPath)) {
-        this.loadAsset(jsonPath, () => setup());
+        this.loadAsset(jsonPath, () => setup(this));
       } else {
         // 复用
-        setup();
+        setup(this);
       }
     } catch (error) {
       console.error('Live2d Module err: ' + error);
@@ -1445,6 +1307,120 @@ export default class PixiStage {
   private unlockStageObject(targetName: string) {
     const index = this.lockTransformTarget.findIndex((name) => name === targetName);
     if (index >= 0) this.lockTransformTarget.splice(index, 1);
+  }
+
+  /**
+   * 设置容器的初始定位
+   */
+  // eslint-disable-next-line max-params
+  private setContainerInitialPosition(
+    container: WebGALPixiContainer,
+    childContainer: any,
+    originalWidth: number,
+    originalHeight: number,
+    position: 'center' | 'left' | 'right' | 'bg',
+    isLive2DFigure: boolean,
+    overrideBounds: [number, number, number, number] = [0, 0, 0, 0],
+    xOffset = 0,
+    yOffset = 0,
+    xScale = 1,
+    yScale = 1,
+    isJsonlFigure = false,
+  ) {
+    try {
+      let positioningType = Live2D.positioningType;
+      // 非 Live2D 立绘一律使用 4.5.13 定位
+      if (!isLive2DFigure) {
+        positioningType = PositioningType.W_4_5_13;
+      }
+      // JSONL 立绘在 MyGO 3.0.0 仍然使用 4.5.13 定位
+      if (isJsonlFigure && positioningType === PositioningType.BC_1_0_0) {
+        positioningType = PositioningType.W_4_5_13;
+      }
+
+      const scaleX = this.stageWidth / originalWidth;
+      const scaleY = this.stageHeight / originalHeight;
+      // 背景使用覆盖式缩放，立绘使用适应式缩放
+      let targetScale = 1.0;
+      if (position === 'bg') {
+        targetScale = Math.max(scaleX, scaleY);
+      } else {
+        targetScale = Math.min(scaleX, scaleY);
+        switch (positioningType) {
+          case PositioningType.W_4_5_12:
+            targetScale *= 1.5;
+            break;
+          case PositioningType.BC_1_0_0:
+          case PositioningType.M_3_1_0:
+            targetScale *= 1.25;
+            break;
+        }
+      }
+
+      childContainer.scale.set(targetScale * xScale, targetScale * yScale);
+      childContainer.anchor.set(0.5);
+      childContainer.pivot.x += (overrideBounds[0] + overrideBounds[2]) * 0.5;
+      childContainer.pivot.y += (overrideBounds[1] + overrideBounds[3]) * 0.5;
+
+      switch (positioningType) {
+        case PositioningType.W_4_5_12:
+          childContainer.position.y = this.stageHeight / 1.2 + yOffset;
+          break;
+        case PositioningType.BC_1_0_0:
+        case PositioningType.M_3_1_0:
+          childContainer.position.y = this.stageHeight / 1.8 + yOffset;
+          break;
+        default:
+          childContainer.position.y = this.stageHeight / 2 + yOffset;
+          break;
+      }
+      childContainer.position.x = xOffset;
+
+      if (position === 'bg') {
+        container.setBaseX(this.stageWidth / 2);
+        container.setBaseY(this.stageHeight / 2);
+      } else {
+        const targetWidth = originalWidth * targetScale;
+        const targetHeight = originalHeight * targetScale;
+        // 立绘尽量贴底
+        if (targetHeight < this.stageHeight && !(positioningType === PositioningType.W_4_5_12)) {
+          container.setBaseY(this.stageHeight / 2 + (this.stageHeight - targetHeight) / 2);
+        } else {
+          container.setBaseY(this.stageHeight / 2);
+        }
+        // 立绘左中右
+        if (position === 'center') {
+          container.setBaseX(this.stageWidth / 2);
+        }
+        if (position === 'left') {
+          switch (positioningType) {
+            case PositioningType.BC_1_0_0:
+            case PositioningType.M_3_1_0:
+              container.setBaseX(850);
+              break;
+            default:
+              container.setBaseX(targetWidth / 2);
+              break;
+          }
+        }
+        if (position === 'right') {
+          switch (positioningType) {
+            case PositioningType.BC_1_0_0:
+            case PositioningType.M_3_1_0:
+              container.setBaseX(1710);
+              break;
+            default:
+              container.setBaseX(this.stageWidth - targetWidth / 2);
+              break;
+          }
+        }
+      }
+
+      container.pivot.set(0, this.stageHeight / 2);
+      container.addChild(childContainer);
+    } catch (error) {
+      console.error('设置容器初始位置失败:', error);
+    }
   }
 
   private async initialize() {

--- a/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
@@ -2,7 +2,7 @@ import { webgalStore } from '@/store/store';
 import { IEffect, IFigureAssociatedAnimation, IFigureMetadata, ITransform } from '@/store/stageInterface';
 import { setStage, stageActions } from '@/store/stageReducer';
 import { Live2D, WebGAL } from '@/Core/WebGAL';
-import { baseBlinkParam, baseFocusParam, BlinkParam, FocusParam, PositioningType } from '@/Core/live2DCore';
+import { baseBlinkParam, baseFocusParam, BlinkParam, FocusParam } from '@/Core/live2DCore';
 import { isIOS } from '@/Core/initializeScript';
 import { WebGALPixiContainer } from '@/Core/controller/stage/pixi/WebGALPixiContainer';
 import { addSpineBgImpl, addSpineFigureImpl } from '@/Core/controller/stage/pixi/spine';
@@ -59,6 +59,23 @@ export interface ILive2DRecord {
 //   target: string;
 //   duration: number;
 // }
+
+interface SetContainerInitialPositionOptions {
+  container: WebGALPixiContainer;
+  childContainer: any;
+  originalWidth: number;
+  originalHeight: number;
+  position: 'center' | 'left' | 'right' | 'bg';
+  isLive2DFigure: boolean;
+  overrideBounds?: [number, number, number, number];
+  transform?: {
+    xOffset?: number;
+    yOffset?: number;
+    xScale?: number;
+    yScale?: number;
+  };
+  isJsonlFigure?: boolean;
+}
 
 // @ts-ignore
 window.PIXI = PIXI;
@@ -420,7 +437,14 @@ export default class PixiStage {
            * 重设大小
            */
           const bgSprite = new PIXI.Sprite(texture);
-          this.setContainerInitialPosition(thisBgContainer, bgSprite, texture.width, texture.height, 'bg', false);
+          this.setContainerInitialPosition({
+            container: thisBgContainer,
+            childContainer: bgSprite,
+            originalWidth: texture.width,
+            originalHeight: texture.height,
+            position: 'bg',
+            isLive2DFigure: false,
+          });
         }
       }, 0);
     };
@@ -491,14 +515,14 @@ export default class PixiStage {
            */
           texture.baseTexture.resource.load().then(() => {
             const bgSprite = new PIXI.Sprite(texture);
-            this.setContainerInitialPosition(
-              thisBgContainer,
-              bgSprite,
-              videoResource.source.videoWidth,
-              videoResource.source.videoHeight,
-              'bg',
-              false,
-            );
+            this.setContainerInitialPosition({
+              container: thisBgContainer,
+              childContainer: bgSprite,
+              originalWidth: videoResource.source.videoWidth,
+              originalHeight: videoResource.source.videoHeight,
+              position: 'bg',
+              isLive2DFigure: false,
+            });
           });
         }
       }, 0);
@@ -564,14 +588,14 @@ export default class PixiStage {
            * 重设大小
            */
           const figureSprite = new PIXI.Sprite(texture);
-          this.setContainerInitialPosition(
-            thisFigureContainer,
-            figureSprite,
-            texture.width,
-            texture.height,
-            presetPosition,
-            false,
-          );
+          this.setContainerInitialPosition({
+            container: thisFigureContainer,
+            childContainer: figureSprite,
+            originalWidth: texture.width,
+            originalHeight: texture.height,
+            position: presetPosition,
+            isLive2DFigure: false,
+          });
         }
       }, 0);
     };
@@ -625,7 +649,14 @@ export default class PixiStage {
       // ✅ 使用 AnimatedGIF.fromBuffer 异步解码
       const gif = await AnimatedGIF.fromBuffer(buffer);
 
-      this.setContainerInitialPosition(thisFigureContainer, gif, gif.width, gif.height, presetPosition, false);
+      this.setContainerInitialPosition({
+        container: thisFigureContainer,
+        childContainer: gif,
+        originalWidth: gif.width,
+        originalHeight: gif.height,
+        position: presetPosition,
+        isLive2DFigure: false,
+      });
 
       // ✅ 播放动画 + 添加到容器
       gif.play();
@@ -728,20 +759,17 @@ export default class PixiStage {
           if (!model) continue;
           // 暂时隐藏模型，等全部模型加载后再统一显示
           model.visible = false;
-          this.setContainerInitialPosition(
-            container,
-            model,
-            model.width,
-            model.height,
-            presetPosition,
-            true,
-            undefined, // 聚合模型暂时想不到怎么使用 overrideBounds
-            x,
-            y,
-            xscale,
-            yscale,
-            true,
-          );
+          this.setContainerInitialPosition({
+            container: container,
+            childContainer: model,
+            originalWidth: model.width,
+            originalHeight: model.height,
+            position: presetPosition,
+            isLive2DFigure: true,
+            // overrideBounds: [0, 0, 0, 0]    // 聚合模型暂时想不到怎么使用 overrideBounds
+            transform: { xOffset: x, yOffset: y, xScale: xscale, yScale: yscale },
+            isJsonlFigure: true,
+          });
           models.push(model);
 
           // 每个模型加载完立刻设置 PARAM_IMPORT
@@ -826,14 +854,14 @@ export default class PixiStage {
 
       // 加载后获取原始宽高
       video.onloadedmetadata = () => {
-        this.setContainerInitialPosition(
-          thisFigureContainer,
-          sprite,
-          video.videoWidth,
-          video.videoHeight,
-          presetPosition,
-          false,
-        );
+        this.setContainerInitialPosition({
+          container: thisFigureContainer,
+          childContainer: sprite,
+          originalWidth: video.videoWidth,
+          originalHeight: video.videoHeight,
+          position: presetPosition,
+          isLive2DFigure: false,
+        });
       };
 
       // 错误处理
@@ -911,15 +939,15 @@ export default class PixiStage {
             ]);
 
             models.forEach((model) => {
-              stage.setContainerInitialPosition(
-                thisFigureContainer,
-                model,
-                model.width,
-                model.height,
-                pos,
-                true,
-                overrideBounds,
-              );
+              stage.setContainerInitialPosition({
+                container: thisFigureContainer,
+                childContainer: model,
+                originalWidth: model.width,
+                originalHeight: model.height,
+                position: pos,
+                isLive2DFigure: true,
+                overrideBounds: overrideBounds,
+              });
 
               let animation_index = 0;
               let priority_number = 3;
@@ -1312,30 +1340,33 @@ export default class PixiStage {
   /**
    * 设置容器的初始定位
    */
-  // eslint-disable-next-line max-params
-  private setContainerInitialPosition(
-    container: WebGALPixiContainer,
-    childContainer: any,
-    originalWidth: number,
-    originalHeight: number,
-    position: 'center' | 'left' | 'right' | 'bg',
-    isLive2DFigure: boolean,
-    overrideBounds: [number, number, number, number] = [0, 0, 0, 0],
-    xOffset = 0,
-    yOffset = 0,
-    xScale = 1,
-    yScale = 1,
-    isJsonlFigure = false,
-  ) {
+  private setContainerInitialPosition(options: SetContainerInitialPositionOptions) {
+    const {
+      container,
+      childContainer,
+      originalWidth,
+      originalHeight,
+      position,
+      isLive2DFigure,
+      overrideBounds = [0, 0, 0, 0],
+      transform: { xOffset = 0, yOffset = 0, xScale = 1, yScale = 1 } = {
+        xOffset: 0,
+        yOffset: 0,
+        xScale: 1,
+        yScale: 1,
+      },
+      isJsonlFigure,
+    } = options;
+
     try {
       let positioningType = Live2D.positioningType;
-      // 非 Live2D 立绘一律使用 4.5.13 定位
+      // 非 Live2D 立绘一律使用 4.5.13 定位 ('M_2_4')
       if (!isLive2DFigure) {
-        positioningType = PositioningType.W_4_5_13;
+        positioningType = 'M_2_4';
       }
       // JSONL 立绘在 MyGO 3.0.0 仍然使用 4.5.13 定位
-      if (isJsonlFigure && positioningType === PositioningType.BC_1_0_0) {
-        positioningType = PositioningType.W_4_5_13;
+      if (isJsonlFigure && positioningType === 'M_3_0_0') {
+        positioningType = 'M_2_4';
       }
 
       const scaleX = this.stageWidth / originalWidth;
@@ -1347,11 +1378,11 @@ export default class PixiStage {
       } else {
         targetScale = Math.min(scaleX, scaleY);
         switch (positioningType) {
-          case PositioningType.W_4_5_12:
+          case 'M_2_3':
             targetScale *= 1.5;
             break;
-          case PositioningType.BC_1_0_0:
-          case PositioningType.M_3_1_0:
+          case 'M_3_0_0':
+          case 'M_3_1_0':
             targetScale *= 1.25;
             break;
         }
@@ -1363,11 +1394,11 @@ export default class PixiStage {
       childContainer.pivot.y += (overrideBounds[1] + overrideBounds[3]) * 0.5;
 
       switch (positioningType) {
-        case PositioningType.W_4_5_12:
+        case 'M_2_3':
           childContainer.position.y = this.stageHeight / 1.2 + yOffset;
           break;
-        case PositioningType.BC_1_0_0:
-        case PositioningType.M_3_1_0:
+        case 'M_3_0_0':
+        case 'M_3_1_0':
           childContainer.position.y = this.stageHeight / 1.8 + yOffset;
           break;
         default:
@@ -1383,7 +1414,7 @@ export default class PixiStage {
         const targetWidth = originalWidth * targetScale;
         const targetHeight = originalHeight * targetScale;
         // 立绘尽量贴底
-        if (targetHeight < this.stageHeight && !(positioningType === PositioningType.W_4_5_12)) {
+        if (targetHeight < this.stageHeight && !(positioningType === 'M_2_3')) {
           container.setBaseY(this.stageHeight / 2 + (this.stageHeight - targetHeight) / 2);
         } else {
           container.setBaseY(this.stageHeight / 2);
@@ -1394,8 +1425,8 @@ export default class PixiStage {
         }
         if (position === 'left') {
           switch (positioningType) {
-            case PositioningType.BC_1_0_0:
-            case PositioningType.M_3_1_0:
+            case 'M_3_0_0':
+            case 'M_3_1_0':
               container.setBaseX(850);
               break;
             default:
@@ -1405,8 +1436,8 @@ export default class PixiStage {
         }
         if (position === 'right') {
           switch (positioningType) {
-            case PositioningType.BC_1_0_0:
-            case PositioningType.M_3_1_0:
+            case 'M_3_0_0':
+            case 'M_3_1_0':
               container.setBaseX(1710);
               break;
             default:

--- a/packages/webgal/src/Core/live2DCore.ts
+++ b/packages/webgal/src/Core/live2DCore.ts
@@ -27,12 +27,21 @@ export const baseFocusParam: FocusParam = {
   instant: false,
 };
 
+export enum PositioningType {
+  W_4_5_12, // WebGAL 4.5.12及以前版本, MyGO 2.3及以前版本
+  W_4_5_13, // WebGAL 4.5.13及以后版本, MyGO 2.4, MyGO 2.5
+  BC_1_0_0, // BandoriCraft 1.0.0及以后版本, MyGO3.0.0
+  M_3_1_0, // MyGO 3.1.0及以后版本
+}
+
 export class Live2DCore {
   public isAvailable = false;
 
   public Live2DModel: any;
   public SoundManager: any;
   public Config: any;
+
+  public positioningType = PositioningType.M_3_1_0;
 
   // 临时记录未初始化前的数据
   // 旧版表情混合模式

--- a/packages/webgal/src/Core/live2DCore.ts
+++ b/packages/webgal/src/Core/live2DCore.ts
@@ -27,12 +27,11 @@ export const baseFocusParam: FocusParam = {
   instant: false,
 };
 
-export enum PositioningType {
-  W_4_5_12, // WebGAL 4.5.12及以前版本, MyGO 2.3及以前版本
-  W_4_5_13, // WebGAL 4.5.13及以后版本, MyGO 2.4, MyGO 2.5
-  BC_1_0_0, // BandoriCraft 1.0.0及以后版本, MyGO3.0.0
-  M_3_1_0, // MyGO 3.1.0及以后版本
-}
+type PositioningType =
+  | 'M_2_3' // ('W_4_5_12' 及以前) | ('M_2_3')， WebGAL 4.5.12及以前版本, MyGO 2.3及以前版本
+  | 'M_2_4' // ('W_4_5_13' 及以后) | ('M_2_4' | 'M_2_5')， WebGAL 4.5.13及以后版本, MyGO 2.4, MyGO 2.5
+  | 'M_3_0_0' // ('BC_1_0_0' 及以后) | ('M_3_0_0')， BandoriCraft 1.0.0及以后版本, MyGO3.0.0
+  | 'M_3_1_0'; // ('M_3_1_0' 及以后)， MyGO 3.1.0及以后版本
 
 export class Live2DCore {
   public isAvailable = false;
@@ -41,7 +40,7 @@ export class Live2DCore {
   public SoundManager: any;
   public Config: any;
 
-  public positioningType = PositioningType.M_3_1_0;
+  public positioningType: PositioningType = 'M_3_1_0';
 
   // 临时记录未初始化前的数据
   // 旧版表情混合模式

--- a/packages/webgal/src/Core/util/coreInitialFunction/infoFetcher.ts
+++ b/packages/webgal/src/Core/util/coreInitialFunction/infoFetcher.ts
@@ -8,6 +8,7 @@ import { initKey } from '@/Core/controller/storage/fastSaveLoad';
 import { getFastSaveFromStorage, getSavesFromStorage } from '@/Core/controller/storage/savesController';
 import { logger } from '@/Core/util/logger';
 import axios from 'axios';
+import { PositioningType } from '@/Core/live2DCore';
 
 /**
  * 获取游戏信息
@@ -57,6 +58,22 @@ export const infoFetcher = (url: string) => {
           }
           if (command === 'Legacy_Expression_Blend_Mode') {
             Live2D.legacyExpressionBlendMode = res === true;
+          }
+          if (command === 'Positioning_Type') {
+            switch (res) {
+              case 'W_4_5_12':
+                Live2D.positioningType = PositioningType.W_4_5_12;
+                break;
+              case 'W_4_5_13':
+                Live2D.positioningType = PositioningType.W_4_5_13;
+                break;
+              case 'BC_1_0_0':
+                Live2D.positioningType = PositioningType.BC_1_0_0;
+                break;
+              case 'M_3_1_0':
+                Live2D.positioningType = PositioningType.M_3_1_0;
+                break;
+            }
           }
         }
       }

--- a/packages/webgal/src/Core/util/coreInitialFunction/infoFetcher.ts
+++ b/packages/webgal/src/Core/util/coreInitialFunction/infoFetcher.ts
@@ -8,7 +8,6 @@ import { initKey } from '@/Core/controller/storage/fastSaveLoad';
 import { getFastSaveFromStorage, getSavesFromStorage } from '@/Core/controller/storage/savesController';
 import { logger } from '@/Core/util/logger';
 import axios from 'axios';
-import { PositioningType } from '@/Core/live2DCore';
 
 /**
  * 获取游戏信息
@@ -62,17 +61,23 @@ export const infoFetcher = (url: string) => {
           if (command === 'Positioning_Type') {
             switch (res) {
               case 'W_4_5_12':
-                Live2D.positioningType = PositioningType.W_4_5_12;
+              case 'M_2_3':
+                Live2D.positioningType = 'M_2_3';
                 break;
               case 'W_4_5_13':
-                Live2D.positioningType = PositioningType.W_4_5_13;
+              case 'M_2_4':
+              case 'M_2_5':
+                Live2D.positioningType = 'M_2_4';
                 break;
               case 'BC_1_0_0':
-                Live2D.positioningType = PositioningType.BC_1_0_0;
+              case 'M_3_0_0':
+                Live2D.positioningType = 'M_3_0_0';
                 break;
               case 'M_3_1_0':
-                Live2D.positioningType = PositioningType.M_3_1_0;
+                Live2D.positioningType = 'M_3_1_0';
                 break;
+              default:
+                Live2D.positioningType = 'M_3_1_0';
             }
           }
         }


### PR DESCRIPTION
# 介绍

https://github.com/user-attachments/assets/58aba143-eed0-421a-9985-092f3e463a11

- 统一了所有类型的背景与立绘的定位实现, 抽离成统一的函数
- _[非兼容]_ 将 jsonl 的立绘定位方式与普通 live2d 定位方式统一
- jsonl 立绘现支持眨眼和注视(应该, 我没测)
- 配置文件支持回退 Live2D 的定位方式, 目前有
  - W_4_5_12: WebGAL 4.5.12及以前版本, MyGO 2.3及以前版本
  - W_4_5_13: WebGAL 4.5.13及以后版本, MyGO 2.4, MyGO 2.5
  - BC_1_0_0: BandoriCraft 1.0.0及以后版本, MyGO 3.0.0
  - _(默认值)_ M_3_1_0: MyGO 3.1.0及以后版本
 
config.txt, 大小写敏感
```
Positioning_Type:M_3_1_0;
```

需要测试, 我没测全