### PR TITLE
fix: resume html style

### DIFF
--- a/packages/webgal/index.html
+++ b/packages/webgal/index.html
@@ -7,6 +7,18 @@
     <link rel="manifest" href="/manifest.json" />
     <title>WebGAL</title>
     <style>
+      html {
+        overflow: hidden;
+        position: absolute;
+        width: 100vw;
+        height: 100vh;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        transform-origin: center center;
+        transition: transform 0.5s cubic-bezier(0.215, 0.610, 0.355, 1);
+      }
+      
       body {
         background: black;
       }


### PR DESCRIPTION
# 介绍

修复合并主分支时 64124950d445234d5e43ba9e5aa517286574cab6 意外将 html 样式删除
